### PR TITLE
[PR] Adding resend verification email feature

### DIFF
--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -101,22 +101,9 @@ async def signup(
         auth.send_verification_email(user.email, user.name, token)
     except Exception as e:
         print("Failed to send email. Message:", str(e))
-        try:
-            new_user = users_table.get_user(user.email)
-            users_table.delete_user(new_user.id)
-        except Exception as delete_error:
-            print(
-                "Failed to delete user after email error. Message:",
-                str(delete_error),
-            )
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Failed to send verification email and encountered an error while attempting to delete the user. ",
-            )
-
         raise HTTPException(
-            status_code=status.HTTP_502_BAD_GATEWAY,
-            detail="Failed to send verification email. User has been removed.",
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send verification email. ",
         )
 
     return {
@@ -334,6 +321,65 @@ async def refresh_token(
         "email": user.email,
         "token": new_access_token,
     }
+
+
+@router.post(
+    "/resend-verification-email",
+    responses={
+        404: {
+            "model": DefaultErrorResponse,
+            "description": "Not Found - Email does not exist",
+        },
+        406: {
+            "model": DefaultErrorResponse,
+            "description": "Not Acceptable - Email already verified",
+        },
+        500: {
+            "model": DefaultErrorResponse,
+            "description": "Internal Server Error - Failed to send reset token",
+        },
+    },
+    summary="Send Verification Email",
+    description="Allows a user to request a verification email to authenticate the account if not verified yet.",
+)
+async def resend_verification_email(
+    request_data: UserForgotPasswordRequest,
+    users_table: UsersTable = Depends(get_users_table),
+):
+    auth = Auth()
+
+    try:
+        user = users_table.get_user(request_data.user_email)
+    except DataNotFound:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="User with this email not found",
+        )
+    except RuntimeError as e:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=str(e),
+        )
+    
+    if user.is_verified:
+        raise HTTPException(
+            status_code=status.HTTP_406_NOT_ACCEPTABLE,
+            detail="Email already verified. ",
+        )
+    
+    try:
+        token = auth.create_jwt_token_from_email(user.email)
+        auth.send_verification_email(user.email, user.name, token)
+    except Exception as e:
+        print("Failed to send email. Message:", str(e))
+           
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to send verification email. ",
+        )
+
+    return {"message": "Email verification token sent successfully to your email."}
+
 
 
 @router.post(

--- a/backend/app/routes/auth.py
+++ b/backend/app/routes/auth.py
@@ -360,26 +360,27 @@ async def resend_verification_email(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=str(e),
         )
-    
+
     if user.is_verified:
         raise HTTPException(
             status_code=status.HTTP_406_NOT_ACCEPTABLE,
             detail="Email already verified. ",
         )
-    
+
     try:
         token = auth.create_jwt_token_from_email(user.email)
         auth.send_verification_email(user.email, user.name, token)
     except Exception as e:
         print("Failed to send email. Message:", str(e))
-           
+
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail="Failed to send verification email. ",
         )
 
-    return {"message": "Email verification token sent successfully to your email."}
-
+    return {
+        "message": "Email verification token sent successfully to your email."
+    }
 
 
 @router.post(

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -40,9 +40,10 @@ interface LayoutProps {
   password: string;
   setPassword: (_password: string) => void;
   initialValues: LoginFormValues;
+  resendEmail: boolean;
 }
 
-const MobileLayout: React.FC<LayoutProps> = ({ handleSubmit, showPassword, setShowPassword, loginError, rememberMe, setRememberMe, setEmail, setPassword, initialValues}) => (
+const MobileLayout: React.FC<LayoutProps> = ({ handleSubmit, showPassword, setShowPassword, loginError, rememberMe, setRememberMe, setEmail, setPassword, initialValues, resendEmail}) => (
     <div className="min-h-screen md:h-screen max-h-full flex items-center justify-center">
         <div className="relative w-full min-h-screen h-full flex flex-col items-center justify-center bg-white px-[10vw] sd:px-[15vw] md:px-[20vw] overflow-hidden">
         
@@ -175,6 +176,16 @@ const MobileLayout: React.FC<LayoutProps> = ({ handleSubmit, showPassword, setSh
               <p className="text-red-500 text-sm mb-4">{loginError}</p>
             )}
 
+            {resendEmail && (
+              <div className="mt-2 mb-4 text-[#2F2B3D]/[90%] text-sm">
+                Caso precise reenviar o e-mail de verificação, clique{" "}
+                <Link href="/resend-verification-email" className="underline cursor-pointer text-[#103768]">
+                  aqui
+                </Link>{" "}
+                !
+              </div>
+            )}
+
             {/* Login Button */}
             <Button type="submit" disabled={isSubmitting} className="mb-4">
               {isSubmitting ? "Enviando..." : "Login"}
@@ -205,7 +216,7 @@ const MobileLayout: React.FC<LayoutProps> = ({ handleSubmit, showPassword, setSh
     </div>
 );
 
-const DesktopLayout: React.FC<LayoutProps> = ({handleSubmit, showPassword, setShowPassword, loginError, rememberMe, setRememberMe, email, setEmail,password,setPassword, initialValues}) => (
+const DesktopLayout: React.FC<LayoutProps> = ({handleSubmit, showPassword, setShowPassword, loginError, rememberMe, setRememberMe, email, setEmail,password,setPassword, initialValues, resendEmail}) => (
     <div className="min-h-screen flex">
         {/* HERO*/}
         <div className="flex-grow bg-white flex items-center justify-center p-[20px]">
@@ -365,6 +376,16 @@ const DesktopLayout: React.FC<LayoutProps> = ({handleSubmit, showPassword, setSh
               <p className="text-red-500 text-sm mb-4">{loginError}</p>
             )}
 
+            {resendEmail && (
+              <div className="mt-2 mb-4 text-[#2F2B3D]/[90%] text-sm">
+                Caso precise reenviar o e-mail de verificação, clique{" "}
+                <Link href="/resend-verification-email" className="underline cursor-pointer text-[#103768]">
+                  aqui
+                </Link>{" "}
+                !
+              </div>
+            )}
+
             {/* Login Button */}
             <Button type="submit" disabled={isSubmitting} className="mb-4">
               {isSubmitting ? "Enviando..." : "Login"}
@@ -401,6 +422,7 @@ export default function Login() {
   const [loading, setLoading] = useState(true);
   const [apiUrl, setApiUrl] = useState('');
   const router = useRouter();
+  const [resendEmail, setResendEmail] = useState(false);
   
   useEffect(() => {
 
@@ -435,6 +457,10 @@ export default function Login() {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
+  const handleResendEmailPageRedirect = () => {
+    router.push("/resend-verification-email");
+  };
+
 const handleSubmit = async (
   values: LoginFormValues,
   { setSubmitting }: FormikHelpers<LoginFormValues>
@@ -464,11 +490,14 @@ const handleSubmit = async (
         
     if (err.response) {
         if (err.response.status === 401 || err.response.status === 406) {
-            setLoginError("Usuário ou senha inválido");
+          setLoginError("Usuário ou senha inválido");
+        } else if(err.response.status === 425) {
+          setLoginError("Verificação de e-mail pendente. Verifique seu e-mail e tente novamente.");
+          setResendEmail(true);
         } else {
-            console.error(err.response.headers);
-            setLoginError("Ocorreu um erro. Tente novamente mais tarde.");
-        }
+          console.error(err.response.headers);
+          setLoginError("Ocorreu um erro. Tente novamente mais tarde.");
+      }
       } else if (err.request) {
         console.error("Erro de rede ou servidor indisponível");
         setLoginError("Servidor indisponível. Tente novamente mais tarde.");
@@ -503,6 +532,7 @@ const handleSubmit = async (
           password={password}
           setPassword={setPassword}
           initialValues={initialValues}
+          resendEmail={resendEmail}
         />
       ) : (
         <DesktopLayout
@@ -517,6 +547,7 @@ const handleSubmit = async (
           password={password}
           setPassword={setPassword}
           initialValues={initialValues}
+          resendEmail={resendEmail}
         />
       )}
     </>

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -457,10 +457,6 @@ export default function Login() {
     return () => window.removeEventListener("resize", handleResize);
   }, []);
 
-  const handleResendEmailPageRedirect = () => {
-    router.push("/resend-verification-email");
-  };
-
 const handleSubmit = async (
   values: LoginFormValues,
   { setSubmitting }: FormikHelpers<LoginFormValues>

--- a/frontend/src/app/resend-verification-email/page.tsx
+++ b/frontend/src/app/resend-verification-email/page.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import Link from "next/link";
+import { Formik, Form, Field, ErrorMessage } from "formik";
+import * as Yup from "yup";
+import axios from "axios";
+import Button from "../../components/GradientButton";
+import { useRouter } from 'next/navigation'; 
+import AuthPopup from '../../components/AuthPopup';
+import { isEmailValid} from '../../hooks/validationSchema';
+
+
+
+interface SendVerificationEmailValues {
+  user_email: string;
+}
+
+const validationSchema = Yup.object().shape({
+  user_email: Yup.string()
+    .email("Formato de email inválido")
+    .required("Email é obrigatório"),
+});
+
+const SendVerificationEmail = () => {
+  const [message, setMessage] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [apiUrl, setApiUrl] = useState("");
+  const [isPopupOpen, setIsPopupOpen] = useState(false);
+  const [isEmailSent, setIsEmailSent] = useState(false);
+
+  const router = useRouter();
+
+  useEffect(() => {
+
+    const fetchApiUrl = async () => {
+      const response = await fetch('/api');
+      const data = await response.json();
+      setApiUrl(data.apiUrl);
+    };
+
+    fetchApiUrl();
+  });
+
+  const handleSubmit = async (values: SendVerificationEmailValues) => {
+    setLoading(true);
+    try {
+
+      const response = await axios.post(`${apiUrl}/resend-verification-email`, values);
+
+      if (response.status === 200) {
+        setMessage("Acesse seu e-mail para autenticar sua conta.");
+        if (isEmailValid(values.user_email)) {
+          setIsEmailSent(true);
+        } else {
+          setIsEmailSent(false);
+        }
+        setIsPopupOpen(true);
+      }
+      
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        if (error.response && error.response.status === 404) {
+          setMessage("Email não encontrado. Verifique e tente novamente.");
+        } else if (error.response && error.response.status === 406) {
+          setMessage("Sua conta já esta verificada. Volte ao Login para acessar a plataforma.");
+        } else {
+          setMessage("Ocorreu um erro. Tente novamente mais tarde.");
+        }
+      }
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+  <div className="fixed inset-0 flex items-center justify-center bg-[rgb(255,255,255,0.95)]">
+      <div className="relative w-full min-h-screen h-full flex flex-col items-center justify-center px-[2vw] sd:px-[10vw] md:px-[15vw] overflow-hidden">
+        <div className="absolute z-[-1] w-full h-full flex justify-center items-center">
+            <div
+                className="md:hidden h-full bg-cover bg-no-repeat w-full transform scale-x-[-1] z-0"
+                style={{
+                    backgroundImage: "url('/images/identidade-visual/Ativo-11linhas.png')",
+                    opacity: 0.90,
+                }}
+            ></div>
+            
+            <div
+                className="hidden md:block bg-cover bg-no-repeat transform scale-x-[-1] z-0 w-[100vw] h-[20vw] "
+                style={{
+                    backgroundImage: `url('/images/identidade-visual/Ativo-6.png')`,
+                    backgroundSize: 'cover',
+                    backgroundPosition: 'center',
+                    backgroundRepeat: 'no-repeat',
+                }}
+            ></div>
+        </div>
+
+
+
+
+          <div className="bg-white rounded-lg shadow-lg py-6 px-6 sm:py-6 sm:px-8 md:py-8 md:px-20 max-w-[80%] sm:max-w-[60%] md:max-w-[500px] w-full">
+              <h1 className="text-md sm:text-lg md:text-2xl font-semibold text-gray-800 mb-4 text-center mt-2 md:mt-4">
+                  Precisa reenviar o e-mail de verificação ?
+              </h1>
+              <p className="text-xs sm:text-sm md:text-md text-gray-600 text-center mb-4 md:mb-6">
+                  Insira seu email que enviaremos um email para verificar sua conta.
+              </p>
+
+              <Formik
+                  initialValues={{ user_email: "" }}
+                  validationSchema={validationSchema}
+                  onSubmit={handleSubmit}
+              >
+                  {({ isSubmitting }) => (
+                      <Form className="w-full">
+                          <div className="mb-4">
+                              <Field
+                                  name="user_email"
+                                  placeholder="E-mail"
+                                  type="email"
+                                  className="w-full p-2 md:p-3 text-black shadow-lg rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 transition duration-200 sm:text-sm"
+                                  style={{
+                                      boxShadow: "0 4px 20px rgba(0, 0, 0, 0.2)",
+                                      border: "none",
+                                  }}
+                              />
+                              <ErrorMessage
+                                  name="user_email"
+                                  component="div"
+                                  className="text-red-500 text-xs sm:text-sm mt-1"
+                              />
+                          </div>
+
+                          {message && (
+                              <p className="text-center text-xs sm:text-sm md:text-md text-gray-700 mb-4">
+                                  {message}
+                              </p>
+                          )}
+
+                          <Button
+                              type="submit"
+                              className="w-full py-2 mt-2 md:mt-3 text-xs sm:text-sm md:text-md"
+                              disabled={isSubmitting || loading}
+                          >
+                              {loading ? "Enviando..." : "Enviar"}
+                          </Button>
+
+
+                          <div className="text-center mt-2 md:mt-3 mb-2">
+                              <Link
+                                  href="/"
+                                  className="text-xs sm:text-sm md:text-md text-[#103768] hover:text-[#103768] hover:font-semibold"
+                              >
+                                  Voltar ao Login
+                              </Link>
+                          </div>
+                      </Form>
+                  )}
+              </Formik>
+          </div>
+      </div>
+      <AuthPopup
+        isOpen={isPopupOpen}
+        onClose={() => setIsPopupOpen(false)}
+        emailSent={isEmailSent}
+        router={router}
+      />
+  </div>
+
+
+  );
+};
+
+export default SendVerificationEmail;

--- a/frontend/src/app/verify/[token]/page.tsx
+++ b/frontend/src/app/verify/[token]/page.tsx
@@ -88,8 +88,8 @@ const VerifyEmail = () => {
     router.push("/");
   };
 
-  const handleSignUpRedirect = () => {
-    router.push("/signup");
+  const handleResendEmailPageRedirect = () => {
+    router.push("/resend-verification-email");
   };
 
   return (
@@ -140,10 +140,10 @@ const VerifyEmail = () => {
                     Pedimos desculpa, infelizmente ocorreu um erro e seu cadastro não foi validado.
                   </p>
                   <p className="text-[16px] sm:text-[18px] text-[#2F2B3D]/[70%] mb-8 text-justify">
-                    Clique no botão para tentarmos enviar outro e-mail de verificação.
+                    Clique no botão para redirecionar para a página de reenviar o e-mail.
                   </p>
-                  <Button onClick={handleSignUpRedirect} className="mb-4 p-2">
-                    Enviar e-mail
+                  <Button onClick={handleResendEmailPageRedirect} className="mb-4 p-2">
+                    Reenvio de e-mail
                   </Button>
                 </div>
               )}


### PR DESCRIPTION
---
### Context  
- We didn’t have a solution for cases where the verification email token had expired or when the email failed to send.  
- We have implemented a feature to delete the user if the email fails to send.  

---
### Solution  
- Created a page to resend the verification email if the user is not verified yet.  
- Added a button or link to this page on the verification page and the login page.  

---
### Notes  

You can test this in two workflows:  

1. **Token Expired**:  
   - Create an account and wait until the token expires (30 minutes, or modify the expiration time locally for testing).  
   - After expiration, the verification page from the email link will display a button that redirects to the new "Resend Verification Email" page.  

2. **Email Not Received**:  
   - If you didn’t receive the email or it got lost in your inbox, try logging in with the correct email and password.  
   - If your account is not verified yet, the login page will notify you and suggest resending the verification email.  

---
### Testing  

- Follow the two workflows described above locally.  
- Test edge cases, such as:  
  - Resending multiple emails.  
  - Attempting to resend an email when the user is already verified.  
